### PR TITLE
ci(workflow): add cache to workflows using actions/setup-node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,24 +2,25 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   macosx:
     runs-on: macos-10.15
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
-    - run: npm install
-    - run: npm test
-    - run: ./build.sh
-    - uses: actions/upload-artifact@v1
-      with:
-        name: alfred-emoji-macosx.alfredworkflow
-        path: alfred-emoji.alfredworkflow
-
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          cache: npm
+      - run: npm install
+      - run: npm test
+      - run: ./build.sh
+      - uses: actions/upload-artifact@v1
+        with:
+          name: alfred-emoji-macosx.alfredworkflow
+          path: alfred-emoji.alfredworkflow
   # macos11:
   #   runs-on: macos-11.0
   #   steps:


### PR DESCRIPTION
## Description

Add `cache` to workflows using `actions/setup-node`

## Context

`setup-node` GitHub Action just released a new option to add cache to steps using it.

You can find the details here: https://github.blog/changelog/2021-07-02-github-actions-setup-node-now-supports-dependency-caching/

---

🤖 This PR has been generated automatically by [this octoherd script](https://github.com/oscard0m/octoherd-script-add-cache-to-node-github-action), feel free to run it in your GitHub user/org repositories! 💪🏾
